### PR TITLE
使用可能な絵文字のライセンスページリンクの追加

### DIFF
--- a/emoji/license/index.html
+++ b/emoji/license/index.html
@@ -50,6 +50,7 @@ function FP_getObjectByID(id,o) {//v1.0
 <p>・tanoshii.site 理由:交友関係</p>
 <p>・ward2.bouvardia.icu 理由:○共保のため</p>
 <p>新規使用許諾希望インスタンスは<a href="mailto:kon2etonertannu@ilnk.info">こちらへ</a></p>
+<p>えとねるんで使用できる一部のカスタム絵文字のライセンスに関しては、<a href="https://msk.ilnk.info/@emoji_informal/pages/license">こちらから</a>ご確認ください。</p>
 <p><a href="../../emoji">
 <img id="img1" alt="戻る" height="20" onmousedown="FP_swapImg(1,0,/*id*/'img1',/*url*/'button13.gif')" onmouseout="FP_swapImg(0,0,/*id*/'img1',/*url*/'button11.gif')" onmouseover="FP_swapImg(1,0,/*id*/'img1',/*url*/'button12.gif')" onmouseup="FP_swapImg(0,0,/*id*/'img1',/*url*/'button12.gif')" src="button11.gif" style="border: 0" width="100" /><!-- MSComment="ibutton" fp-style="fp-btn: Embossed Capsule 8; fp-transparent: 1" fp-title="戻る" --></a></p>
 <p>&nbsp;</p>


### PR DESCRIPTION
えとねるんで使用できる一部カスタム絵文字のライセンスについて書かれたMisskeyのページへのリンクを追加しました。

「えとねるんカスタム絵文字ライセンス」というタイトルのため、ここに追加してもいいのではないかと考えました。